### PR TITLE
Updated how views and controllers re render

### DIFF
--- a/src/main/python/MainWindowController.py
+++ b/src/main/python/MainWindowController.py
@@ -1,8 +1,7 @@
-#Controlador de la vista MainWindow
+# Controlador de la vista MainWindow
 import sys
 import re
 from PyQt5 import QtWidgets, QtCore
-# from FluidezVerbalController import *
 from MainWindowWithListWidget import *
 from ReporteModel import *
 from datetime import datetime
@@ -45,7 +44,7 @@ class MainWindowController(QtWidgets.QWidget, ControllerModel):
 
 	def getDatos(self):
 		"""
-		 Método que toma los datos ingresados en la vista de Fluidez Verbal
+		 Método que toma los datos ingresados en la vista de Informacion de Sujeto
 		"""
 		vista = self.mainWindowView
 		nombre = vista.leName.text()

--- a/src/main/python/MasterController.py
+++ b/src/main/python/MasterController.py
@@ -218,9 +218,12 @@ class MasterController:
          Args:
           elemSelected: Lista que contiene el elemento seleccionado
         """
-        self.nextWindow, self.nextController = self.router.getRouteViewAndController(
-            elemSelected)
-        # print("hola", self.nextWindow, self.nextController, elemSelected)
+        self.nextWindow, self.nextController = self.router.getRouteViewAndController(elemSelected)
+        
+        if elemSelected == "report":
+            self.router.setController(elemSelected, self.nextController.__class__, self.reporteModel)
+            self.nextWindow, self.nextController = self.router.getRouteViewAndController(elemSelected)
+            
         progress = self.getRouteProgress(elemSelected)
         self.menuController.updateCurrentWindow(progress)
 
@@ -336,8 +339,8 @@ class MasterController:
                 if not isinstance(prevPrueba, ReporteModel):
                     self.reporteModel.addPrueba(prevPrueba)
 
-                self.router.setController(
-                    nameKey, ClassRef, self.reporteModel)
+                if self.router.getController(nameKey) is None or nameKey == "report" :
+                    self.router.setController(nameKey, ClassRef, self.reporteModel)
 
                 self.addPaginaVisitada(nameKey)
                 self.menuController.updatePagesVisited(self.paginasVisitadas)


### PR DESCRIPTION
Existia un problema al intentar modificar la informacion de una prueba previamente submiteada que hacia que la prueba siguiente se volviera a crear aun cuando esta tuviera informacion.

Tambien se agrego la funcionalidad de siempre crear el controller del Reporte aun cuando se accese desde el MenuController para asegurar que tenga la informacion mas reciente.