### PR TITLE
Parche bug prueba D2

### DIFF
--- a/src/main/python/pruebas/D2Prueba.py
+++ b/src/main/python/pruebas/D2Prueba.py
@@ -35,7 +35,9 @@ class D2Prueba(PruebaModel.PruebaModel):
 		ppC = auxC['Percentil']
 
 		tot = tr - (o + c)
+		if tot < 0: tot = 0
 		con = ta - c 
+		if con < 0: con = 0
 
 		tempValores = self.valores
 		self.valores = (tempValores[0], tempValores[1], tempValores[2], tempValores[3], tot, con, self.valores[4])


### PR DESCRIPTION
Con un tr menor a la suma de o y c obtenemos un tot negativo y los varemos parten de 0
Se agregó un parche para que los números negativos se conviertan en 0